### PR TITLE
Infinite loop fix #8 and CDN update #7

### DIFF
--- a/cytoscape.js-navigator.js
+++ b/cytoscape.js-navigator.js
@@ -489,7 +489,7 @@
     }
 
   , _hookGraphUpdates: function () {
-      this.cy.on('position add remove data', $.proxy(this._checkThumbnailSizesAndUpdate, this, false))
+      this.cy.on('position add remove data style', $.proxy(this._checkThumbnailSizesAndUpdate, this, false))
     }
 
   , _setGraphUpdatesTimer: function () {
@@ -536,8 +536,7 @@
 
       // Copy scaled thumbnail to buffer
       that.cy.renderTo(cxt, zoom, pan, pxRatio);
-
-      cytoscape.util.requestAnimationFrame( render );
+      that._thumbnailUpdating = false;
     }
 
     cytoscape.util.requestAnimationFrame( render );

--- a/demo.html
+++ b/demo.html
@@ -9,7 +9,7 @@
 
 		<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
 
-		<script src="//cdnjs.cloudflare.com/ajax/libs/cytoscape/2.3.1/cytoscape.min.js"></script>
+		<script src="//cdnjs.cloudflare.com/ajax/libs/cytoscape/2.3.7/cytoscape.min.js"></script>
 
 		<script src="cytoscape.js-navigator.js"></script>
 


### PR DESCRIPTION
Hi @maxkfranz, @bumbu , this PR is for fixing the demo for issue #7 and for fix the high CPU demand on #8.

To limit the rendering requests on the navigator, I've removed the requestAnimationLoop. 

The event listener will manage the rendering updates, that are in a way limited to thanks to the requestAnimationFrame and the _thumbnailUpdating check.

I've add also the *style* property to the event listener.

Finally just an update on the demo.html cytoscape CDN library solving issue #7 
