### PR TITLE
fix(styles): fix image overflow on HiDPI media

### DIFF
--- a/cytoscape.js-navigator.css
+++ b/cytoscape.js-navigator.css
@@ -10,6 +10,11 @@
 	overflow: hidden;
 }
 
+.cytoscape-navigator > img{
+	max-width: 100%;
+	max-height: 100%;
+}
+
 .cytoscape-navigator > canvas{
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
The thumbnail image will overflow on HiDPI media (namely retina screen on Apple's marketing). It can be fixed by setting constraints on image.