### PR TITLE
Fix for bug # 32 in cytoscape-navigator

### DIFF
--- a/cytoscape-navigator.js
+++ b/cytoscape-navigator.js
@@ -354,8 +354,9 @@
           return
         }
       } else {
-        this.$panel = $('<div class="cytoscape-navigator"/>')
-        $('body').append(this.$panel)
+        var $container = $(this);
+        this.$panel = $('<div class="cytoscape-navigator"/>');
+        $container.get(0).$element.append(this.$panel);
       }
 
       this._setupPanel()


### PR DESCRIPTION
Grabbing the parent container by default instead of just appending the navigator to the body.