### PR TITLE
(Docs) Fix description of `container` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Plain HTML/JS has the extension registered for you automatically, because no `re
 var cy = cytoscape({ /* ... */ });
 
 var defaults = {
-    container: false // html dom element
+    container: false // string | false | undefined. Supported strings: an element id selector (like "#someId"), or a className selector (like ".someClassName"). Otherwise an element will be created by the library.
   , viewLiveFramerate: 0 // set false to update graph pan only on drag end; set 0 to do it instantly; set a number (frames per second) to update not more than N times per second
   , thumbnailEventFramerate: 30 // max thumbnail's updates per second triggered by graph updates
   , thumbnailLiveFramerate: false // max thumbnail's updates per second. Set false to disable


### PR DESCRIPTION
Resolves https://github.com/cytoscape/cytoscape.js-navigator/issues/53