### PR TITLE
Update navigator css with better z-index

### DIFF
--- a/cytoscape.js-navigator.css
+++ b/cytoscape.js-navigator.css
@@ -2,7 +2,7 @@
 	position: fixed;
 	border: 1px solid #000;
 	background: #fff;
-	z-index: 99999;
+	z-index: 2147483647;
 	width: 400px;
 	height: 400px;
 	bottom: 0;


### PR DESCRIPTION
The highest z-index value is 2147483647, using 99999 is a bad practice reference: 
- https://www.w3.org/TR/CSS21/visuren.html#z-index
- https://stackoverflow.com/questions/491052/minimum-and-maximum-value-of-z-index